### PR TITLE
Fix select PDF button not opening file dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       <div class="viewer-scroll">
         <div class="viewer-stage">
           <div class="file-input-panel">
-            <input type="file" id="fileInput" accept="application/pdf" hidden />
+            <input type="file" id="fileInput" accept="application/pdf" />
             <label class="file-input-button" for="fileInput">
               <span class="file-input-button__icon" aria-hidden="true">&#128194;</span>
               <span>Select PDF</span>


### PR DESCRIPTION
## Summary
- remove the hidden attribute from the PDF file input so the label can trigger the picker

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d63cf82734832e9269ec9efd8f6940