### PR TITLE
Ensure Select PDF button opens native picker reliably

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,12 +46,23 @@
       <div class="viewer-scroll">
         <div class="viewer-stage">
           <div class="file-input-panel">
-            <input type="file" id="fileInput" accept="application/pdf" hidden />
-            <label class="file-input-button" for="fileInput">
+            <input
+              type="file"
+              id="fileInput"
+              class="file-input-native"
+              accept="application/pdf"
+              aria-describedby="fileInputHint"
+              aria-labelledby="filePickerTrigger"
+            />
+            <button
+              type="button"
+              id="filePickerTrigger"
+              class="file-input-button"
+            >
               <span class="file-input-button__icon" aria-hidden="true">&#128194;</span>
               <span>Select PDF</span>
-            </label>
-            <p class="file-input-hint">or drag & drop a PDF onto the page below</p>
+            </button>
+            <p id="fileInputHint" class="file-input-hint">or drag & drop a PDF onto the page below</p>
           </div>
           <div id="viewer" class="placeholder">
             <div class="drop-overlay" aria-hidden="true">

--- a/src/styles/viewer.css
+++ b/src/styles/viewer.css
@@ -29,10 +29,21 @@
   gap: 12px;
   margin: 0 0 16px;
   text-align: center;
+  position: relative;
 }
 
-.file-input-panel input[type="file"] {
-  display: none;
+.file-input-native {
+  position: absolute;
+  inset: auto;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
 }
 
 .file-input-button {
@@ -321,43 +332,6 @@
 }
 
 /* ---------- Viewer ---------- */
-.drop-overlay {
-  position: absolute;
-  inset: 0;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  gap: 12px;
-  border: 2px dashed rgba(255, 255, 255, 0.35);
-  border-radius: 18px;
-  background: rgba(40, 32, 38, 0.12);
-  color: var(--muted);
-  text-align: center;
-  pointer-events: none;
-  padding: 24px;
-}
-
-#viewer.placeholder .drop-overlay {
-  display: flex;
-}
-
-#viewer.is-dragover .drop-overlay {
-  border-color: rgba(255, 122, 162, 0.85);
-  background: rgba(255, 122, 162, 0.18);
-  color: var(--accent);
-}
-
-.drop-overlay__icon {
-  font-size: 2.2rem;
-}
-
-.drop-overlay__text {
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-
 .drop-overlay {
   position: absolute;
   inset: 0;

--- a/src/ui/uiHandlers.js
+++ b/src/ui/uiHandlers.js
@@ -7,10 +7,19 @@ export function setupFileInput(onFileSelected) {
   const input = document.getElementById("fileInput");
   const viewer = document.getElementById("viewer");
   const filePanel = document.querySelector(".file-input-panel");
+  const trigger = document.getElementById("filePickerTrigger");
+
+  if (!input) {
+    console.error("fileInput element not found in index.html");
+    return;
+  }
 
   const resetInput = () => {
-    if (!input) return;
-    try { input.value = ""; } catch {}
+    try {
+      input.value = "";
+    } catch (error) {
+      console.warn("Unable to reset file input", error);
+    }
   };
 
   const isPdfFile = (file) => {
@@ -19,84 +28,104 @@ export function setupFileInput(onFileSelected) {
     return file.name?.toLowerCase().endsWith(".pdf");
   };
 
-  const processFile = async (file) => {
-    if (!file || !isPdfFile(file)) {
-      if (file) console.warn("Ignored non-PDF file drop:", file.name);
+  const handleFile = async (file) => {
+    if (!file) return;
+    if (!isPdfFile(file)) {
+      console.warn("Ignored non-PDF file:", file.name ?? "unknown");
       return;
     }
-    console.log("User selected file:", file.name);
-    await onFileSelected(file);
+
+    try {
+      await onFileSelected(file);
+    } finally {
+      resetInput();
+    }
   };
 
-  if (!input) {
-    console.error("fileInput element not found in index.html");
-  } else {
-    input.addEventListener("change", async (e) => {
-      const file = e.target.files && e.target.files[0];
-      if (!file) return;
-      try {
-        await processFile(file);
-      } finally {
-        resetInput();
+  const openPicker = () => {
+    try {
+      if (typeof input.showPicker === "function") {
+        input.showPicker();
+      } else {
+        input.click();
       }
-    });
+    } catch (error) {
+      console.error("Failed to open file picker", error);
+      input.click();
+    }
+  };
+
+  input.addEventListener("change", (event) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      void handleFile(file);
+    }
+  });
+
+  trigger?.addEventListener("click", openPicker);
+
+  if (!viewer) {
+    return;
   }
 
-  if (!viewer) return;
-
   const setDragState = (active) => {
-    viewer.classList.toggle("is-dragover", !!active);
+    viewer.classList.toggle("is-dragover", Boolean(active));
   };
 
   const isReadyForDrop = () => viewer.classList.contains("placeholder");
 
-  const handleDragOver = (e) => {
+  const handleDragOver = (event) => {
     if (!isReadyForDrop()) return;
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "copy";
+    }
     setDragState(true);
   };
 
-  const handleDragLeave = (e) => {
+  const handleDragLeave = (event) => {
     if (!isReadyForDrop()) return;
+    const related = event.relatedTarget;
     if (
-      e.relatedTarget &&
-      (viewer.contains(e.relatedTarget) || filePanel?.contains(e.relatedTarget))
+      related &&
+      (viewer.contains(related) || (filePanel && filePanel.contains(related)))
     ) {
       return;
     }
     setDragState(false);
   };
 
-  ["dragenter", "dragover"].forEach((evt) => viewer.addEventListener(evt, handleDragOver));
-  ["dragleave", "dragend"].forEach((evt) => viewer.addEventListener(evt, handleDragLeave));
-  viewer.addEventListener("drop", async (e) => {
+  const handleDrop = (event) => {
     if (!isReadyForDrop()) return;
-    e.preventDefault();
+    event.preventDefault();
     setDragState(false);
-    const file = e.dataTransfer?.files?.[0];
-    if (!file) return;
-    await processFile(file);
-    resetInput();
-  });
+    const file = event.dataTransfer?.files?.[0];
+    if (file) {
+      void handleFile(file);
+    }
+  };
+
+  ["dragenter", "dragover"].forEach((type) =>
+    viewer.addEventListener(type, handleDragOver),
+  );
+  ["dragleave", "dragend"].forEach((type) =>
+    viewer.addEventListener(type, handleDragLeave),
+  );
+  viewer.addEventListener("drop", handleDrop);
 
   if (filePanel) {
-    ["dragenter", "dragover"].forEach((evt) => filePanel.addEventListener(evt, handleDragOver));
-    ["dragleave", "dragend"].forEach((evt) => filePanel.addEventListener(evt, handleDragLeave));
-    filePanel.addEventListener("drop", async (e) => {
-      if (!isReadyForDrop()) return;
-      e.preventDefault();
-      setDragState(false);
-      const file = e.dataTransfer?.files?.[0];
-      if (!file) return;
-      await processFile(file);
-      resetInput();
-    });
+    ["dragenter", "dragover"].forEach((type) =>
+      filePanel.addEventListener(type, handleDragOver),
+    );
+    ["dragleave", "dragend"].forEach((type) =>
+      filePanel.addEventListener(type, handleDragLeave),
+    );
+    filePanel.addEventListener("drop", handleDrop);
   }
 
-  const blockWindowDrop = (e) => {
+  const blockWindowDrop = (event) => {
     if (!isReadyForDrop()) return;
-    e.preventDefault();
+    event.preventDefault();
   };
 
   window.addEventListener("dragover", blockWindowDrop);


### PR DESCRIPTION
## Summary
- replace the Select PDF label with a dedicated trigger button and associate it to the hidden input for accessibility
- centralize file handling logic and ensure the picker opens via `showPicker` with a safe `click` fallback
- deduplicate drop overlay styles to keep the stylesheet tidy

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d63cf82734832e9269ec9efd8f6940