### PR TITLE
Fix viewer header left gap

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,18 +22,25 @@
     <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>
-    <main>
-      <div class="viewer-header">
+    <header class="viewer-header">
+      <div class="viewer-header__inner">
         <h1>PDF Viewer</h1>
-        <button id="btnDownloadAnnotated" type="button" class="viewer-download-btn" aria-label="Download PDF with annotations" title="Download PDF with annotations">
+        <button
+          id="btnDownloadAnnotated"
+          type="button"
+          class="viewer-download-btn"
+          aria-label="Download PDF with annotations"
+          title="Download PDF with annotations"
+        >
           <span class="viewer-download-btn__icon" aria-hidden="true">
             <img src="/src/assets/icons/download.svg" alt="" />
           </span>
           <span class="viewer-download-btn__label">Download</span>
         </button>
-
       </div>
+    </header>
 
+    <main>
       <!-- Toolbar: start hidden but space-reserved to avoid CLS -->
       <div class="toolbar-row">
         <div id="toolbar" class="hydrating" role="toolbar" aria-label="Annotation toolbar"></div>

--- a/src/styles/viewer.css
+++ b/src/styles/viewer.css
@@ -207,11 +207,27 @@
 
 
 .viewer-header {
+  background: linear-gradient(135deg, #fbe5ef 0%, #fff4f9 100%);
+  margin: 0 0 32px;
+  padding: clamp(20px, 4vw, 36px) clamp(24px, 5vw, 48px);
+  border-top: 1px solid rgba(247, 196, 212, 0.6);
+  border-bottom: 1px solid rgba(247, 196, 212, 0.6);
+  box-shadow: 0 6px 18px -14px rgba(109, 61, 84, 0.45);
+}
+
+.viewer-header__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
+  gap: clamp(16px, 4vw, 48px);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.viewer-header h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.1rem);
+  font-weight: 700;
 }
 
 
@@ -257,7 +273,7 @@
 }
 
 @media (max-width: 640px) {
-  .viewer-header {
+  .viewer-header__inner {
     flex-direction: column;
     align-items: stretch;
   }


### PR DESCRIPTION
## Summary
- wrap the viewer header content in an inner container so the background spans the full viewport width without a left gap
- adjust the header styling to align the title and download button within the shared max-width container while keeping a subtle contrasting background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d63f18f848832e9acb44193d29ae46