### PR TITLE
Add viewer actions for printing, sharing, and saving

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,19 +25,59 @@
     <main>
       <div class="page-shell">
         <div class="viewer-header">
-          <h1>PDF Viewer</h1>
-          <button
-            id="btnDownloadAnnotated"
-            type="button"
-            class="viewer-download-btn"
-            aria-label="Download PDF with annotations"
-            title="Download PDF with annotations"
-          >
-            <span class="viewer-download-btn__icon" aria-hidden="true">
-              <img src="/src/assets/icons/download.svg" alt="" />
-            </span>
-            <span class="viewer-download-btn__label">Download</span>
-          </button>
+          <div class="viewer-header__inner">
+            <h1 class="viewer-header__title">PDF Viewer</h1>
+            <div class="viewer-actions" role="group" aria-label="Document actions">
+              <button
+                id="btnDownloadAnnotated"
+                type="button"
+                class="viewer-action-btn viewer-action-btn--primary"
+                aria-label="Download PDF with annotations"
+                title="Download PDF with annotations"
+              >
+                <span class="viewer-action-btn__icon" aria-hidden="true">
+                  <img src="/src/assets/icons/download.svg" alt="" />
+                </span>
+                <span class="viewer-action-btn__label">Download</span>
+              </button>
+              <button
+                id="btnPrintAnnotated"
+                type="button"
+                class="viewer-action-btn viewer-action-btn--secondary"
+                aria-label="Print PDF with annotations"
+                title="Print PDF with annotations"
+              >
+                <span class="viewer-action-btn__icon" aria-hidden="true">
+                  <img src="/src/assets/icons/print.svg" alt="" />
+                </span>
+                <span class="viewer-action-btn__label">Print</span>
+              </button>
+              <button
+                id="btnShareAnnotated"
+                type="button"
+                class="viewer-action-btn viewer-action-btn--secondary"
+                aria-label="Share PDF with annotations"
+                title="Share PDF with annotations"
+              >
+                <span class="viewer-action-btn__icon" aria-hidden="true">
+                  <img src="/src/assets/icons/share.svg" alt="" />
+                </span>
+                <span class="viewer-action-btn__label">Share</span>
+              </button>
+              <button
+                id="btnSaveLocalAnnotated"
+                type="button"
+                class="viewer-action-btn viewer-action-btn--secondary"
+                aria-label="Save annotations locally"
+                title="Save annotations locally"
+              >
+                <span class="viewer-action-btn__icon" aria-hidden="true">
+                  <img src="/src/assets/icons/save.svg" alt="" />
+                </span>
+                <span class="viewer-action-btn__label">Save</span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <!-- Toolbar: start hidden but space-reserved to avoid CLS -->

--- a/src/app/listeners.js
+++ b/src/app/listeners.js
@@ -11,6 +11,9 @@ let bootstrapped = false;
  * @param {{
  *   onRequestImage: () => void,
  *   onDownloadRequested: () => void | Promise<void>,
+ *   onPrintRequested?: () => void | Promise<void>,
+ *   onShareRequested?: () => void | Promise<void>,
+ *   onSaveLocalRequested?: () => void | Promise<void>,
  *   updateRenderConfig: (patchOrConfig: object) => void,
  *   getRenderPrefs: () => object,
  *   toggleGuides: () => object,   // returns new prefs
@@ -23,6 +26,9 @@ let bootstrapped = false;
 export function attachGlobalListeners({
   onRequestImage,
   onDownloadRequested,
+  onPrintRequested,
+  onShareRequested,
+  onSaveLocalRequested,
   updateRenderConfig,
   getRenderPrefs,
   toggleGuides,
@@ -82,10 +88,25 @@ export function attachGlobalListeners({
     await onDownloadRequested?.();
   }
 
+  async function handlePrintRequested() {
+    await onPrintRequested?.();
+  }
+
+  async function handleShareRequested() {
+    await onShareRequested?.();
+  }
+
+  async function handleSaveLocalRequested() {
+    await onSaveLocalRequested?.();
+  }
+
   window.addEventListener("keydown", onShortcut);
   document.addEventListener("keydown", onEsc);
   document.addEventListener("annotator:request-image", handleRequestImage);
   document.addEventListener("annotator:download-requested", handleDownloadRequested);
+  document.addEventListener("annotator:print-requested", handlePrintRequested);
+  document.addEventListener("annotator:share-requested", handleShareRequested);
+  document.addEventListener("annotator:save-local-requested", handleSaveLocalRequested);
 
   if (import.meta?.hot) {
     import.meta.hot.dispose(() => {
@@ -93,6 +114,9 @@ export function attachGlobalListeners({
       document.removeEventListener("keydown", onEsc);
       document.removeEventListener("annotator:request-image", handleRequestImage);
       document.removeEventListener("annotator:download-requested", handleDownloadRequested);
+      document.removeEventListener("annotator:print-requested", handlePrintRequested);
+      document.removeEventListener("annotator:share-requested", handleShareRequested);
+      document.removeEventListener("annotator:save-local-requested", handleSaveLocalRequested);
       bootstrapped = false;
     });
   }

--- a/src/assets/icons/print.svg
+++ b/src/assets/icons/print.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 9V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v5" />
+  <path d="M4 14v-3a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v3" />
+  <rect x="6" y="14" width="12" height="7" rx="1.25" />
+  <path d="M9 17h6" />
+</svg>

--- a/src/assets/icons/save.svg
+++ b/src/assets/icons/save.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 3h11.5L21 7.5V20a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+  <path d="M15 3v5H9V3" />
+  <rect x="8" y="14" width="8" height="6" rx="1.25" />
+</svg>

--- a/src/assets/icons/share.svg
+++ b/src/assets/icons/share.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="6" cy="12" r="2.75" />
+  <circle cx="18" cy="6" r="2.75" />
+  <circle cx="18" cy="18" r="2.75" />
+  <path d="M8.3 10.9 15.7 7.1" />
+  <path d="M8.3 13.1l7.4 3.8" />
+</svg>

--- a/src/pdf/exportAnnotated.js
+++ b/src/pdf/exportAnnotated.js
@@ -2,16 +2,25 @@
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
 import { state } from "../app/state.js";
 
+const PDF_MIME = "application/pdf";
+const NO_PDF_MESSAGE = "Please load a PDF first before exporting.";
+const NO_PDF_ERROR_CODE = "NO_PDF_DATA";
+
+function createNoPdfError() {
+  const error = new Error(NO_PDF_MESSAGE);
+  error.code = NO_PDF_ERROR_CODE;
+  return error;
+}
+
 /**
  * Convert an image src (data: URL or object URL) into bytes and a mime hint.
  */
 async function srcToBytesAndType(src) {
-  // Data URL?
   if (typeof src === "string" && src.startsWith("data:")) {
     const comma = src.indexOf(",");
-    const header = src.slice(5, comma); // e.g., "image/png;base64"
+    const header = src.slice(5, comma);
     const base64 = src.slice(comma + 1);
-    const mime = header.split(";")[0]; // "image/png"
+    const mime = header.split(";")[0];
     const binStr = atob(base64);
     const len = binStr.length;
     const bytes = new Uint8Array(len);
@@ -19,38 +28,84 @@ async function srcToBytesAndType(src) {
     return { bytes, mime };
   }
 
-  // Blob/object URL or remote URL
   const resp = await fetch(src);
   const mime = resp.headers.get("content-type") || "";
   const buf = await resp.arrayBuffer();
   return { bytes: new Uint8Array(buf), mime };
 }
 
-/**
- * Heuristic: decide PNG vs JPEG for pdf-lib embedders.
- */
 function isPngBytes(bytes, mimeHint) {
   if (mimeHint && mimeHint.toLowerCase().includes("png")) return true;
-  // PNG signature: 89 50 4E 47 0D 0A 1A 0A
   if (bytes.length >= 8) {
-    const sig = [0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A];
+    const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
     for (let i = 0; i < sig.length; i++) if (bytes[i] !== sig[i]) return false;
     return true;
   }
   return false;
 }
 
-/**
- * downloadAnnotatedPdf(rawData: Uint8Array, filename: string)
- * Loads a PDF from raw data and adds annotations from state before downloading.
- */
-export async function downloadAnnotatedPdf(rawData, filename = "annotated.pdf") {
-  if (!rawData) {
-    console.warn("[exportAnnotated] No PDF loaded, cannot export.");
-    alert("Please load a PDF first before exporting.");
+function ensurePdfInput(rawData) {
+  if (!rawData) throw createNoPdfError();
+  return rawData;
+}
+
+function triggerDownloadFromBlob(blob, filename = "annotated.pdf") {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function handleExportError(err) {
+  if (!err) return;
+  if (err.code === NO_PDF_ERROR_CODE) {
+    alert(NO_PDF_MESSAGE);
     return;
   }
+  console.error("[exportAnnotated] Export failed", err);
+  alert("Something went wrong while exporting. Please try again.");
+}
 
+async function printBlob(blob) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const iframe = document.createElement("iframe");
+    iframe.style.position = "fixed";
+    iframe.style.width = "0";
+    iframe.style.height = "0";
+    iframe.style.opacity = "0";
+    iframe.style.pointerEvents = "none";
+    iframe.setAttribute("aria-hidden", "true");
+
+    const cleanup = () => {
+      URL.revokeObjectURL(url);
+      iframe.remove();
+    };
+
+    iframe.addEventListener("load", () => {
+      try {
+        const win = iframe.contentWindow;
+        win?.focus?.();
+        win?.print?.();
+        setTimeout(() => {
+          cleanup();
+          resolve();
+        }, 0);
+      } catch (error) {
+        cleanup();
+        reject(error);
+      }
+    });
+
+    iframe.src = url;
+    document.body.appendChild(iframe);
+  });
+}
+
+async function generatePdfDocument(rawData) {
   const pdfDoc = await PDFDocument.load(rawData);
   const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
   const pages = pdfDoc.getPages();
@@ -70,38 +125,42 @@ export async function downloadAnnotatedPdf(rawData, filename = "annotated.pdf") 
         const w = nw * pw;
         const h = nh * ph;
         const x = nx * pw;
-        const y = ph - ny * ph - h; // convert from top-left to PDF bottom-left
+        const y = ph - ny * ph - h;
 
         page.drawRectangle({
-          x, y, width: w, height: h,
-          color: rgb(1, 1, 0), opacity: 0.35,
+          x,
+          y,
+          width: w,
+          height: h,
+          color: rgb(1, 1, 0),
+          opacity: 0.35,
         });
-
       } else if (ann.type === "note" || ann.type === "text") {
-        const text = (ann.text && ann.text.trim()) ? ann.text : "Note";
+        const text = ann.text?.trim() ? ann.text : "Note";
         const fontSize = ann.fontSize || 12;
 
-        let x = 50, y = 50; // defaults
+        let x = 50;
+        let y = 50;
         if (ann.rect) {
-          // Text tool box (normalized rect)
           const [nx, ny, nw, nh] = ann.rect;
           const w = nw * pw;
           const h = nh * ph;
           x = nx * pw;
           y = ph - ny * ph - h;
         } else if (ann.pos) {
-          // Sticky note (normalized point)
           const [nx, ny] = ann.pos;
           x = nx * pw;
           y = ph - ny * ph - fontSize;
         }
 
         page.drawText(text, {
-          x, y, size: fontSize, font, color: rgb(0, 0, 0),
+          x,
+          y,
+          size: fontSize,
+          font,
+          color: rgb(0, 0, 0),
         });
-
       } else if (ann.type === "image" && ann.src) {
-        // ---- IMAGE SUPPORT ----
         try {
           const { bytes, mime } = await srcToBytesAndType(ann.src);
           const embed = isPngBytes(bytes, mime)
@@ -115,18 +174,78 @@ export async function downloadAnnotatedPdf(rawData, filename = "annotated.pdf") 
           const y = ph - ny * ph - h;
 
           page.drawImage(embed, { x, y, width: w, height: h });
-        } catch (e) {
-          console.warn("[exportAnnotated] Failed to embed image:", e);
+        } catch (error) {
+          console.warn("[exportAnnotated] Failed to embed image", error);
         }
       }
     }
   }
 
-  const bytes = await pdfDoc.save();
-  const blob = new Blob([bytes], { type: "application/pdf" });
-  const url = URL.createObjectURL(blob);
+  return pdfDoc;
+}
 
-  const a = document.createElement("a");
-  a.href = url; a.download = filename; a.click();
-  URL.revokeObjectURL(url);
+export async function generateAnnotatedPdfBlob(rawData) {
+  ensurePdfInput(rawData);
+  const pdfDoc = await generatePdfDocument(rawData);
+  const bytes = await pdfDoc.save();
+  return new Blob([bytes], { type: PDF_MIME });
+}
+
+export async function downloadAnnotatedPdf(rawData, filename = "annotated.pdf") {
+  try {
+    const blob = await generateAnnotatedPdfBlob(rawData);
+    triggerDownloadFromBlob(blob, filename);
+  } catch (err) {
+    handleExportError(err);
+  }
+}
+
+export async function printAnnotatedPdf(rawData) {
+  let blob;
+  try {
+    blob = await generateAnnotatedPdfBlob(rawData);
+  } catch (err) {
+    handleExportError(err);
+    return;
+  }
+
+  try {
+    await printBlob(blob);
+  } catch (err) {
+    console.error("[exportAnnotated] Print failed; falling back to download.", err);
+    triggerDownloadFromBlob(blob);
+  }
+}
+
+export async function shareAnnotatedPdf(rawData, filename = "annotated.pdf") {
+  let blob;
+  try {
+    blob = await generateAnnotatedPdfBlob(rawData);
+  } catch (err) {
+    handleExportError(err);
+    return false;
+  }
+
+  const nav = typeof navigator !== "undefined" ? navigator : null;
+  const hasFileCtor = typeof File === "function";
+
+  if (nav?.share && hasFileCtor) {
+    const file = new File([blob], filename, { type: PDF_MIME });
+    const shareData = { files: [file], title: filename };
+    const canShare = typeof nav.canShare === "function" ? nav.canShare(shareData) : true;
+    if (canShare) {
+      try {
+        await nav.share(shareData);
+        return true;
+      } catch (err) {
+        if (err?.name === "AbortError") {
+          return false;
+        }
+        console.warn("[exportAnnotated] navigator.share failed; falling back to download.", err);
+      }
+    }
+  }
+
+  triggerDownloadFromBlob(blob, filename);
+  return false;
 }

--- a/src/styles/viewer.css
+++ b/src/styles/viewer.css
@@ -241,46 +241,82 @@
   font-weight: 700;
 }
 
+.viewer-header__title {
+  margin: 0;
+}
 
+.viewer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 
-.viewer-download-btn {
+.viewer-action-btn {
   display: inline-flex;
   align-items: center;
   gap: 10px;
   border-radius: 18px;
-  border: 1px solid var(--accent);
-  background: var(--accent);
-  color: #fffaf7;
+  border: 1px solid rgba(255, 122, 162, 0.45);
+  background: rgba(255, 122, 162, 0.08);
+  color: var(--accent);
   padding: 12px 20px;
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
-  transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
+  transition:
+    transform .18s ease,
+    box-shadow .18s ease,
+    background .18s ease,
+    color .18s ease,
+    border-color .18s ease;
 }
 
-.viewer-download-btn:hover {
+.viewer-action-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 34px -20px rgba(255, 122, 162, 0.6);
 }
 
-.viewer-download-btn:focus-visible {
+.viewer-action-btn:focus-visible {
   outline: 3px solid rgba(255, 122, 162, 0.45);
   outline-offset: 3px;
 }
 
-.viewer-download-btn__icon {
+.viewer-action-btn__icon {
   display: inline-flex;
   width: 26px;
   height: 26px;
 }
 
-.viewer-download-btn__icon img {
+.viewer-action-btn__icon img {
   width: 100%;
   height: 100%;
 }
 
-.viewer-download-btn__label {
+.viewer-action-btn__label {
   font-size: 0.9rem;
+}
+
+.viewer-action-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fffaf7;
+}
+
+.viewer-action-btn--primary:hover {
+  box-shadow: 0 16px 34px -18px rgba(255, 122, 162, 0.75);
+}
+
+.viewer-action-btn--secondary:hover {
+  background: rgba(255, 122, 162, 0.16);
+  border-color: rgba(255, 122, 162, 0.7);
+}
+
+@media (max-width: 840px) {
+  .viewer-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 640px) {
@@ -289,8 +325,13 @@
     align-items: stretch;
   }
 
-  .viewer-download-btn {
+  .viewer-actions {
     width: 100%;
+    justify-content: center;
+  }
+
+  .viewer-action-btn {
+    flex: 1 1 140px;
     justify-content: center;
   }
 }

--- a/src/ui/toolbar/events.js
+++ b/src/ui/toolbar/events.js
@@ -166,6 +166,14 @@ export function attachToolbarEvents(handlers = {}) {
     }
   };
 
+  const runDocumentAction = (eventName, handlerName, logLabel) => {
+    if (logLabel) log(logLabel);
+    requestAnimationFrame(() => {
+      document.dispatchEvent(new CustomEvent(eventName));
+      safe(handlers[handlerName])();
+    });
+  };
+
   const clickActions = {
     prevPage: () => safe(handlers.onPrev)(),
     nextPage: () => safe(handlers.onNext)(),
@@ -191,13 +199,30 @@ export function attachToolbarEvents(handlers = {}) {
     btnRedo: () => safe(handlers.onRedo)(),
     btnHistoryPanel: () => toggleHistoryPanel(),
     btnHistoryPanelClose: () => closeHistoryPanel({ focusToggle: true }),
-    btnDownloadAnnotated: () => {
-      log("Download annotated");
-      requestAnimationFrame(() => {
-        document.dispatchEvent(new CustomEvent("annotator:download-requested"));
-        safe(handlers.onDownloadAnnotated)();
-      });
-    },
+    btnDownloadAnnotated: () =>
+      runDocumentAction(
+        "annotator:download-requested",
+        "onDownloadAnnotated",
+        "Download annotated"
+      ),
+    btnPrintAnnotated: () =>
+      runDocumentAction(
+        "annotator:print-requested",
+        "onPrintAnnotated",
+        "Print annotated"
+      ),
+    btnShareAnnotated: () =>
+      runDocumentAction(
+        "annotator:share-requested",
+        "onShareAnnotated",
+        "Share annotated"
+      ),
+    btnSaveLocalAnnotated: () =>
+      runDocumentAction(
+        "annotator:save-local-requested",
+        "onSaveLocalAnnotated",
+        "Save annotations locally"
+      ),
   };
 
   toolbarEl.addEventListener(
@@ -308,17 +333,25 @@ export function attachToolbarEvents(handlers = {}) {
     { signal }
   );
 
-  const downloadBtn = q("btnDownloadAnnotated");
-  if (downloadBtn && clickActions.btnDownloadAnnotated) {
-    downloadBtn.addEventListener(
+  const headerActionButtons = [
+    "btnDownloadAnnotated",
+    "btnPrintAnnotated",
+    "btnShareAnnotated",
+    "btnSaveLocalAnnotated",
+  ];
+
+  headerActionButtons.forEach((id) => {
+    const button = q(id);
+    if (!button || !clickActions[id]) return;
+    button.addEventListener(
       "click",
       (e) => {
         e.preventDefault();
-        clickActions.btnDownloadAnnotated();
+        clickActions[id]();
       },
       { signal }
     );
-  }
+  });
 
   const picker = firstEl("imagePickerInput", "imagePicker");
   if (picker && handlers.onImageSelected) {


### PR DESCRIPTION
## Summary
- add a grouped viewer header action bar with download, print, share, and local save controls plus matching icons
- extend toolbar events and global listeners so the new actions dispatch annotator events alongside the existing download hook
- refactor the annotated export helper to share blob generation while supporting download, print, and share flows with graceful fallbacks

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d642e25fb8832ebe953c676e005d1d